### PR TITLE
Futures/async based worker

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
   "debug.allowBreakpointsEverywhere": true,
-  "editor.rulers": [80,120]
+  "editor.rulers": [100,120]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ edition = "2018"
 
 [dependencies]
 num_cpus = "1.13.0"
+rand = "0.8.3"
 log = "0.4"
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drumbeat"
-version = "0.1.0"
+version = "0.1.1"
 description = "An event handling system aimed towards real-time applications such as GUIs and Game Engines."
 authors = ["Patrick Hadlaw <patrickhadlaw@gmail.com>"]
 repository = "https://github.com/patrickhadlaw/drumbeat-rs"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # drumbeat-rs
 
-![Crates.io](https://img.shields.io/crates/v/drumbeat) ![Docs.rs](https://docs.rs/drumbeat/badge.svg) ![Crates.io](https://img.shields.io/crates/d/drumbeat) ![Build & Check](https://github.com/patrickhadlaw/drumbeat-rs/workflows/Build%20&%20Check/badge.svg)
+[![Crates.io](https://img.shields.io/crates/v/drumbeat)](https://crates.io/crates/drumbeat)
+[![Docs.rs](https://docs.rs/drumbeat/badge.svg)](https://docs.rs/drumbeat)
+[![Crates.io](https://img.shields.io/crates/d/drumbeat)](https://crates.io/crates/drumbeat)
+[![Build & Check](https://github.com/patrickhadlaw/drumbeat-rs/workflows/Build%20&%20Check/badge.svg)](https://github.com/patrickhadlaw/drumbeat-rs/actions?query=workflow%3A%22Build+%26+Check%22)
 
 An event handling system aimed towards real-time applications such as GUIs and Game Engines. Drumbeat is heavily inspired by the Observer pattern and its interface is inspired by some Reactive X libraries. However, this crate intends to be aimed towards real-time applications as described before.
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -37,10 +37,7 @@ fn main() {
       .pipe()
       .map(|x| EventType::EventA(x.unwrap().pow(2)))
       .observe(),
-    b.observe()
-      .pipe()
-      .map(|x| EventType::EventB(x.unwrap() * 3))
-      .observe(),
+    b.observe().pipe().map(|x| EventType::EventB(x.unwrap() * 3)).observe(),
   ]);
   let rx = merge.pipe().tap(|x| println!("{}", x)).take(6).collect();
   // Since a, b and merge are using the default worker scheduler, the following

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-max_width = 80
+max_width = 120
 tab_spaces = 2

--- a/src/event/dispatcher.rs
+++ b/src/event/dispatcher.rs
@@ -1,6 +1,4 @@
-use super::observable::{
-  DummyOwner, Observable, ObservableType, Owner, Signal,
-};
+use super::observable::{DummyOwner, Observable, ObservableType, Owner, Signal};
 use crate::sync::buffer::RingBuffer;
 use crate::sync::threadpool::Task;
 
@@ -57,9 +55,7 @@ where
 {
   match dispatch_type {
     DispatcherType::Basic => Box::new(BasicDispatcher::new()),
-    DispatcherType::Replay(size) => {
-      Box::new(ReplayDispatcher::new(size, false))
-    }
+    DispatcherType::Replay(size) => Box::new(ReplayDispatcher::new(size, false)),
   }
 }
 
@@ -92,10 +88,7 @@ where
 }
 
 #[derive(Clone)]
-pub(super) struct DispatchTarget<T>(
-  pub(super) Arc<dyn Owner>,
-  pub(super) Invoker<T>,
-)
+pub(super) struct DispatchTarget<T>(pub(super) Arc<dyn Owner>, pub(super) Invoker<T>)
 where
   T: ObservableType;
 
@@ -358,16 +351,9 @@ where
   }
 
   fn bootstrap(&self, child: usize) -> Option<Task> {
-    if let Some(target) = self
-      .base
-      .children
-      .iter()
-      .find(|target| target.0.id() == child)
-    {
+    if let Some(target) = self.base.children.iter().find(|target| target.0.id() == child) {
       let cloned = target.0.clone();
-      let replay = self
-        .buffer
-        .get_and_do(self.buffer.size(), move || cloned.initialize());
+      let replay = self.buffer.get_and_do(self.buffer.size(), move || cloned.initialize());
       if let Some(owner) = self.owner() {
         let cloned = target.1.clone();
         return Some(Task::new(move || {

--- a/src/event/observable.rs
+++ b/src/event/observable.rs
@@ -1,6 +1,4 @@
-use super::dispatcher::{
-  replicate, DispatchTarget, Dispatcher, DispatcherType, Invoker, ReplayDispatcher, SubscriptionDispatcher,
-};
+use super::dispatcher::{replicate, DispatchTarget, Dispatcher, DispatcherType, Invoker, SubscriptionDispatcher};
 use super::scheduler::{make_scheduler, Scheduler, SchedulerType};
 use super::subscription::Subscription;
 use crate::sync::threadpool::Task;

--- a/src/event/observable.rs
+++ b/src/event/observable.rs
@@ -354,15 +354,13 @@ where
   }
 
   fn finish(&self) {
-    if let Ok(last) = self.finished.compare_exchange(
+    if self.finished.compare_exchange(
       false,
       true,
       Ordering::Relaxed,
       Ordering::Relaxed,
-    ) {
-      if !last {
-        self.pipeable.read().unwrap().finalize();
-      }
+    ).is_ok() {
+      self.pipeable.read().unwrap().finalize();
     }
   }
 

--- a/src/event/ops.rs
+++ b/src/event/ops.rs
@@ -170,12 +170,10 @@ where
       .pipe()
       .first()
       .tap(move |_| {
-        if closed.compare_exchange(
-          false,
-          true,
-          Ordering::Relaxed,
-          Ordering::Relaxed,
-        ).is_ok() {
+        if closed
+          .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+          .is_ok()
+        {
           use super::scheduler::{Runtime, Scheduler};
           use crate::sync::threadpool::Task;
           let runtime = Runtime {};
@@ -248,12 +246,10 @@ where
         observable,
         Invoker::new(Arc::new(move |x| {
           let good = predicate(x.clone());
-          if finished.compare_exchange(
-            false,
-            !good,
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-          ).is_ok() {
+          if finished
+            .compare_exchange(false, !good, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+          {
             cloned.next(x);
             if !good {
               return Signal::Recycle(cloned.id());
@@ -453,12 +449,7 @@ where
         })),
       ),
     );
-    let pipe = pipe.finalize(move || {
-      tx.lock()
-        .unwrap()
-        .send(cloned.lock().unwrap().clone())
-        .unwrap()
-    });
+    let pipe = pipe.finalize(move || tx.lock().unwrap().send(cloned.lock().unwrap().clone()).unwrap());
     pipe.instantiate();
     rx
   }
@@ -608,11 +599,7 @@ where
     let (tx, rx) = std::sync::mpsc::channel();
     let finalize = Mutex::new(tx.clone());
     self.finalize(move || {
-      finalize
-        .lock()
-        .unwrap()
-        .send(DebounceCommand::Finish)
-        .unwrap();
+      finalize.lock().unwrap().send(DebounceCommand::Finish).unwrap();
     });
     let rx = Mutex::new(rx);
     worker.submit(async move || {
@@ -814,10 +801,7 @@ mod test {
   #[test]
   fn assert_test() {
     utils::testing::async_context(|| {
-      let observable = observable::testing::mock_observable::<()>(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
+      let observable = observable::testing::mock_observable::<()>(SchedulerType::Blocking, DispatcherType::Basic);
       observable.pipe().assert(|_| true).dangling();
       observable.next(());
     });
@@ -827,10 +811,7 @@ mod test {
   #[should_panic]
   fn assert_panic_test() {
     utils::testing::async_panic_context(|| {
-      let observable = observable::testing::mock_observable::<()>(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
+      let observable = observable::testing::mock_observable::<()>(SchedulerType::Blocking, DispatcherType::Basic);
       observable.pipe().assert(|_| false).dangling();
       observable.next(());
     });
@@ -839,10 +820,7 @@ mod test {
   #[test]
   fn assert_count_test() {
     utils::testing::async_context(|| {
-      let observable = observable::testing::mock_observable::<()>(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
+      let observable = observable::testing::mock_observable::<()>(SchedulerType::Blocking, DispatcherType::Basic);
       observable.pipe().assert_count(3).dangling();
       observable.next(());
       observable.next(());
@@ -854,10 +832,7 @@ mod test {
   #[should_panic]
   fn assert_count_panic_test() {
     utils::testing::async_panic_context(|| {
-      let observable = observable::testing::mock_observable::<()>(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
+      let observable = observable::testing::mock_observable::<()>(SchedulerType::Blocking, DispatcherType::Basic);
       observable.pipe().assert_count(3).dangling();
       observable.next(());
     });
@@ -866,10 +841,7 @@ mod test {
   #[test]
   fn tap_test() {
     utils::testing::async_context(|| {
-      let observable = observable::testing::mock_observable(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
+      let observable = observable::testing::mock_observable(SchedulerType::Blocking, DispatcherType::Basic);
       let count = Arc::new(AtomicUsize::new(0));
       let cloned = count.clone();
       observable
@@ -889,16 +861,8 @@ mod test {
   #[test]
   fn debounce_test() {
     utils::testing::async_context(|| {
-      let observable = observable::testing::mock_observable(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
-      let rx = observable
-        .pipe()
-        .take(100)
-        .assert_count(100)
-        .debounce()
-        .collect();
+      let observable = observable::testing::mock_observable(SchedulerType::Blocking, DispatcherType::Basic);
+      let rx = observable.pipe().take(100).assert_count(100).debounce().collect();
       for i in 0..100 {
         observable.next(i);
         if i == 50 {
@@ -912,10 +876,7 @@ mod test {
   #[test]
   fn map_test() {
     utils::testing::async_context(|| {
-      let observable = observable::testing::mock_observable(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
+      let observable = observable::testing::mock_observable(SchedulerType::Blocking, DispatcherType::Basic);
       observable
         .pipe()
         .map(|x| format!("test_{}", x))
@@ -928,16 +889,8 @@ mod test {
   #[test]
   fn take_test() {
     utils::testing::async_context(|| {
-      let observable = observable::testing::mock_observable(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
-      observable
-        .pipe()
-        .take(3)
-        .assert(|x| x <= 3)
-        .assert_count(3)
-        .dangling();
+      let observable = observable::testing::mock_observable(SchedulerType::Blocking, DispatcherType::Basic);
+      observable.pipe().take(3).assert(|x| x <= 3).assert_count(3).dangling();
       observable.next(1);
       observable.next(2);
       observable.next(3);
@@ -949,14 +902,8 @@ mod test {
   #[test]
   fn take_until_test() {
     utils::testing::async_context(|| {
-      let observable = observable::testing::mock_observable(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
-      let done = observable::testing::mock_observable::<()>(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
+      let observable = observable::testing::mock_observable(SchedulerType::Blocking, DispatcherType::Basic);
+      let done = observable::testing::mock_observable::<()>(SchedulerType::Blocking, DispatcherType::Basic);
       observable
         .pipe()
         .take_until(done.clone())
@@ -976,10 +923,7 @@ mod test {
   #[test]
   fn take_while_test() {
     utils::testing::async_context(|| {
-      let observable = observable::testing::mock_observable(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
+      let observable = observable::testing::mock_observable(SchedulerType::Blocking, DispatcherType::Basic);
       observable
         .pipe()
         .take_while(|x| x < 3)
@@ -997,16 +941,8 @@ mod test {
   #[test]
   fn first_test() {
     utils::testing::async_context(|| {
-      let observable = observable::testing::mock_observable(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
-      observable
-        .pipe()
-        .first()
-        .assert(|x| x == 1)
-        .assert_count(1)
-        .dangling();
+      let observable = observable::testing::mock_observable(SchedulerType::Blocking, DispatcherType::Basic);
+      observable.pipe().first().assert(|x| x == 1).assert_count(1).dangling();
       observable.next(1);
       assert_eq!(observable.num_children(), 0);
       observable.next(2);
@@ -1018,16 +954,8 @@ mod test {
   #[test]
   fn skip_test() {
     utils::testing::async_context(|| {
-      let observable = observable::testing::mock_observable(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
-      observable
-        .pipe()
-        .skip(2)
-        .assert(|x| x > 2)
-        .assert_count(2)
-        .dangling();
+      let observable = observable::testing::mock_observable(SchedulerType::Blocking, DispatcherType::Basic);
+      observable.pipe().skip(2).assert(|x| x > 2).assert_count(2).dangling();
       observable.next(1);
       observable.next(2);
       observable.next(3);
@@ -1038,10 +966,7 @@ mod test {
   #[test]
   fn filter_test() {
     utils::testing::async_context(|| {
-      let observable = observable::testing::mock_observable(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
+      let observable = observable::testing::mock_observable(SchedulerType::Blocking, DispatcherType::Basic);
       observable
         .pipe()
         .filter(|x| x % 3 == 0)
@@ -1060,10 +985,7 @@ mod test {
   #[test]
   fn collect_test() {
     utils::testing::async_context(|| {
-      let observable = observable::testing::mock_observable(
-        SchedulerType::Blocking,
-        DispatcherType::Basic,
-      );
+      let observable = observable::testing::mock_observable(SchedulerType::Blocking, DispatcherType::Basic);
       let rx = observable.pipe().take(3).assert_count(3).collect();
       observable.next(1);
       observable.next(2);

--- a/src/event/ops.rs
+++ b/src/event/ops.rs
@@ -565,12 +565,12 @@ where
   ///   .pipe()
   ///   .take(100)
   ///   .assert_count(100)
-  ///   .debounce_for(Duration::from_millis(100))
+  ///   .debounce_for(Duration::from_millis(400))
   ///   .collect();
   /// for i in 0..100 {
   ///   subject.next(i);
   ///   if i == 50 {
-  ///     std::thread::sleep(Duration::from_millis(150));
+  ///     std::thread::sleep(Duration::from_millis(500));
   ///   }
   /// }
   /// assert_eq!(rx.recv().unwrap(), [50]);

--- a/src/event/scheduler.rs
+++ b/src/event/scheduler.rs
@@ -18,7 +18,7 @@ pub trait Scheduler: Send + Sync {
 
 impl Scheduler for Worker {
   fn execute(&self, task: Task) {
-    self.submit(async move || { task.invoke() });
+    self.submit(async move || task.invoke());
   }
 
   fn scheduler_type(&self) -> SchedulerType {
@@ -60,16 +60,10 @@ impl Scheduler for Blocking {
   }
 }
 
-pub(super) fn make_scheduler(
-  name: String,
-  id: usize,
-  strategy: SchedulerType,
-) -> Arc<dyn Scheduler> {
+pub(super) fn make_scheduler(name: String, id: usize, strategy: SchedulerType) -> Arc<dyn Scheduler> {
   match strategy {
     SchedulerType::Worker => Arc::new(Worker::new()),
-    SchedulerType::Pool => {
-      Arc::new(ThreadPoolBuilder::named(format!("{}{}", name, id)).build())
-    }
+    SchedulerType::Pool => Arc::new(ThreadPoolBuilder::named(format!("{}{}", name, id)).build()),
     SchedulerType::Runtime => Arc::new(Runtime {}),
     SchedulerType::Blocking => Arc::new(Blocking {}),
   }

--- a/src/event/scheduler.rs
+++ b/src/event/scheduler.rs
@@ -18,7 +18,7 @@ pub trait Scheduler: Send + Sync {
 
 impl Scheduler for Worker {
   fn execute(&self, task: Task) {
-    self.submit_raw(task);
+    self.submit(async move || { task.invoke() });
   }
 
   fn scheduler_type(&self) -> SchedulerType {

--- a/src/event/subject.rs
+++ b/src/event/subject.rs
@@ -1,7 +1,5 @@
 use super::dispatcher::{create, DispatcherType};
-use super::observable::{
-  DummyOwner, Observable, ObservableType, Owner, Signal,
-};
+use super::observable::{DummyOwner, Observable, ObservableType, Owner, Signal};
 use super::scheduler::{make_scheduler, Scheduler, SchedulerType};
 use crate::sync::threadpool::Task;
 
@@ -84,10 +82,7 @@ impl<T> SubjectBase<T>
 where
   T: ObservableType,
 {
-  pub(super) fn new(
-    strategy: SchedulerType,
-    dispatch_type: DispatcherType,
-  ) -> Self {
+  pub(super) fn new(strategy: SchedulerType, dispatch_type: DispatcherType) -> Self {
     let id = super::observable::id();
     SubjectBase {
       id,
@@ -473,9 +468,7 @@ mod test {
 
   #[test]
   fn basic_subject_new_pool_test() {
-    let basic = BasicSubjectBuilder::new()
-      .scheduler(SchedulerType::Pool)
-      .build::<()>();
+    let basic = BasicSubjectBuilder::new().scheduler(SchedulerType::Pool).build::<()>();
     let read_guard = basic.base.manager.read().unwrap();
     assert!(read_guard.subject.upgrade().is_some());
     assert_eq!(read_guard.scheduler.scheduler_type(), SchedulerType::Pool);
@@ -488,10 +481,7 @@ mod test {
       .build::<()>();
     let read_guard = basic.base.manager.read().unwrap();
     assert!(read_guard.subject.upgrade().is_some());
-    assert_eq!(
-      read_guard.scheduler.scheduler_type(),
-      SchedulerType::Runtime
-    );
+    assert_eq!(read_guard.scheduler.scheduler_type(), SchedulerType::Runtime);
   }
 
   #[test]
@@ -501,10 +491,7 @@ mod test {
       .build::<()>();
     let read_guard = basic.base.manager.read().unwrap();
     assert!(read_guard.subject.upgrade().is_some());
-    assert_eq!(
-      read_guard.scheduler.scheduler_type(),
-      SchedulerType::Blocking
-    );
+    assert_eq!(read_guard.scheduler.scheduler_type(), SchedulerType::Blocking);
   }
 
   #[test]
@@ -538,10 +525,7 @@ mod test {
       .build::<()>();
     let read_guard = queuing.base.manager.read().unwrap();
     assert!(read_guard.subject.upgrade().is_some());
-    assert_eq!(
-      read_guard.scheduler.scheduler_type(),
-      SchedulerType::Runtime
-    );
+    assert_eq!(read_guard.scheduler.scheduler_type(), SchedulerType::Runtime);
   }
 
   #[test]
@@ -551,18 +535,13 @@ mod test {
       .build::<()>();
     let read_guard = queuing.base.manager.read().unwrap();
     assert!(read_guard.subject.upgrade().is_some());
-    assert_eq!(
-      read_guard.scheduler.scheduler_type(),
-      SchedulerType::Blocking
-    );
+    assert_eq!(read_guard.scheduler.scheduler_type(), SchedulerType::Blocking);
   }
 
   #[test]
   fn queuing_subject_push_flush_test() {
     async_context(|| {
-      let subject = QueuingSubjectBuilder::new()
-        .scheduler(SchedulerType::Blocking)
-        .build();
+      let subject = QueuingSubjectBuilder::new().scheduler(SchedulerType::Blocking).build();
       let count = Arc::new(AtomicIsize::new(0));
       let clone = count.clone();
       let _subscription = subject.observe().pipe().subscribe(move |_| {

--- a/src/event/subscription.rs
+++ b/src/event/subscription.rs
@@ -13,11 +13,7 @@ impl Subscription {
   pub(super) fn new(subscriber: Weak<dyn Owner>) -> Self {
     Subscription {
       subscriber: subscriber.clone(),
-      _scheduler: if let Some(subscriber) = subscriber.upgrade() {
-        Some(subscriber.scheduler())
-      } else {
-        None
-      },
+      _scheduler: subscriber.upgrade().map(|subscriber| subscriber.scheduler()),
     }
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //! * a real-time focused synchronization library implementing thread workers,
 //!   thread pools and a multithreaded runtime.
 #![feature(negative_impls)]
-#![feature(wake_trait)]
 #![feature(async_closure)]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,10 @@
 //! * a real-time focused, observer pattern based, multithreaded event system.
 //! * a real-time focused synchronization library implementing thread workers,
 //!   thread pools and a multithreaded runtime.
+#![feature(negative_impls)]
+#![feature(wake_trait)]
+#![feature(async_closure)]
+
 #[macro_use]
 extern crate lazy_static;
 

--- a/src/sync/buffer.rs
+++ b/src/sync/buffer.rs
@@ -1,11 +1,13 @@
-use super::spinlock::SpinLock;
-use std::cell::UnsafeCell;
+use super::spinlock::{SpinLock, SpinLockGuard};
+
+struct RingBufferInner<T> {
+  front: usize,
+  filled: bool,
+  raw: Vec<T>,
+}
 
 pub struct RingBuffer<T> {
-  lock: SpinLock,
-  front: UnsafeCell<usize>,
-  filled: UnsafeCell<bool>,
-  raw: UnsafeCell<Vec<T>>,
+  inner: SpinLock<RingBufferInner<T>>,
   size: usize,
 }
 
@@ -15,10 +17,11 @@ where
 {
   pub fn new(size: usize) -> RingBuffer<T> {
     RingBuffer {
-      lock: SpinLock::new(),
-      front: UnsafeCell::new(0),
-      filled: UnsafeCell::new(false),
-      raw: UnsafeCell::new(Vec::new()),
+      inner: SpinLock::new(RingBufferInner {
+        front: 0,
+        filled: false,
+        raw: Vec::new(),
+      }),
       size,
     }
   }
@@ -28,48 +31,46 @@ where
   }
 
   pub fn push(&self, value: T) {
-    unsafe {
-      self.lock.lock();
-      #[allow(unused_mut)]
-      let mut raw = &mut *self.raw.get();
-      if raw.len() < self.size {
-        raw.push(value);
-      } else {
-        raw[*self.front.get()] = value;
-      }
-      *self.front.get() = (*self.front.get() + 1) % self.size;
-      if *self.front.get() == 0 {
-        *self.filled.get() = true;
-      }
-      self.lock.unlock();
+    let mut guard = self.inner.lock().unwrap();
+    if guard.raw.len() < self.size {
+      guard.raw.push(value);
+    } else {
+      guard.raw[guard.front] = value;
+    }
+    guard.front = (guard.front + 1) % self.size;
+    if guard.front == 0 {
+      guard.filled = true;
     }
   }
 
-  unsafe fn get_critical(&self, num: usize) -> Vec<T> {
+  unsafe fn get_critical(
+    &self,
+    guard: &SpinLockGuard<'_, RingBufferInner<T>>,
+    num: usize
+  ) -> Vec<T> {
     let mut result = Vec::new();
     result.reserve(num);
     let fetch = (if num < self.size { num } else { self.size }) as isize;
-    let front = *self.front.get() as isize;
-    let raw = &mut *self.raw.get();
-    if *self.filled.get() {
+    let front = guard.front as isize;
+    if guard.filled {
       let back = if front - fetch < 0 {
         ((self.size as isize) + front - fetch) as usize
       } else {
         (front - fetch) as usize
       };
-      if back < *self.front.get() {
-        for item in raw.iter().take(*self.front.get()).skip(back) {
+      if back < guard.front {
+        for item in guard.raw.iter().take(guard.front).skip(back) {
           result.push(item.clone());
         }
       } else {
-        for i in (back..self.size).chain(0..*self.front.get()) {
-          result.push(raw[i].clone());
+        for i in (back..self.size).chain(0..guard.front) {
+          result.push(guard.raw[i].clone());
         }
       }
     } else {
       let back = front - fetch;
       let start = if back < 0 { 0 } else { back as usize };
-      for item in raw.iter().take(*self.front.get()).skip(start) {
+      for item in guard.raw.iter().take(guard.front).skip(start) {
         result.push(item.clone());
       }
     }
@@ -80,12 +81,9 @@ where
     if num == 0 {
       return Vec::new();
     }
-    unsafe {
-      self.lock.lock();
-      let result = self.get_critical(num);
-      self.lock.unlock();
-      result
-    }
+    let guard = self.inner.lock().unwrap();
+    let result = self.get_critical(&guard, num);
+    result
   }
 
   pub fn get_and_do<F>(&self, num: usize, task: F) -> Vec<T>
@@ -95,13 +93,10 @@ where
     if num == 0 {
       return Vec::new();
     }
-    unsafe {
-      self.lock.lock();
-      let result = self.get_critical(num);
-      task();
-      self.lock.unlock();
-      result
-    }
+    let guard = self.inner.lock().unwrap();
+    let result = self.get_critical(&guard, num);
+    task();
+    result
   }
 
   pub fn get_all(&self) -> Vec<T> {
@@ -122,8 +117,8 @@ mod test {
     let ring = RingBuffer::<()>::new(5);
     assert_eq!(ring.size, 5);
     unsafe {
-      assert_eq!(*ring.filled.get(), false);
-      assert_eq!(*ring.front.get(), 0);
+      assert_eq!(ring.inner.lock().unwrap().filled, false);
+      assert_eq!(ring.inner.lock().unwrap().front, 0);
     }
   }
 
@@ -134,10 +129,8 @@ mod test {
       ring.push(1);
       ring.push(2);
       ring.push(3);
-      unsafe {
-        assert_eq!(ring.raw.get().as_ref().unwrap().len(), 3);
-        assert_eq!(*ring.raw.get(), [1, 2, 3]);
-      }
+      assert_eq!(ring.inner.lock().unwrap().raw.len(), 3);
+      assert_eq!(ring.inner.lock().unwrap().raw, [1, 2, 3]);
     });
   }
 
@@ -151,10 +144,8 @@ mod test {
       ring.push(4);
       ring.push(5);
       ring.push(6);
-      unsafe {
-        assert_eq!(ring.raw.get().as_ref().unwrap().len(), 3);
-        assert_eq!(*ring.raw.get(), [4, 5, 6]);
-      }
+      assert_eq!(ring.inner.lock().unwrap().raw.len(), 3);
+      assert_eq!(ring.inner.lock().unwrap().raw, [4, 5, 6]);
     });
   }
 
@@ -178,9 +169,7 @@ mod test {
       ring.push(3);
       ring.push(4);
       ring.push(5);
-      unsafe {
-        assert_eq!(*ring.filled.get(), true);
-      };
+      assert_eq!(ring.inner.lock().unwrap().filled, true);
       assert_eq!(ring.get(2), [4, 5]);
     });
   }
@@ -194,9 +183,7 @@ mod test {
       ring.push(3);
       ring.push(4);
       ring.push(5);
-      unsafe {
-        assert_eq!(*ring.filled.get(), true);
-      };
+      assert_eq!(ring.inner.lock().unwrap().filled, true);
       assert_eq!(ring.get(3), [3, 4, 5]);
     });
   }

--- a/src/sync/buffer.rs
+++ b/src/sync/buffer.rs
@@ -44,11 +44,7 @@ where
     }
   }
 
-  unsafe fn get_critical(
-    &self,
-    guard: &SpinLockGuard<'_, RingBufferInner<T>>,
-    num: usize
-  ) -> Vec<T> {
+  unsafe fn get_critical(&self, guard: &SpinLockGuard<'_, RingBufferInner<T>>, num: usize) -> Vec<T> {
     let mut result = Vec::new();
     result.reserve(num);
     let fetch = (if num < self.size { num } else { self.size }) as isize;

--- a/src/sync/executor.rs
+++ b/src/sync/executor.rs
@@ -1,0 +1,10 @@
+use super::task::{Task, TaskType};
+
+use std::sync::Arc;
+use std::future::Future;
+
+pub trait Executor {
+  type Output: TaskType;
+  
+  fn execute(&self, future: impl Future<Output=Self::Output> + Send + 'static) -> Arc<Task<Self::Output>>;
+}

--- a/src/sync/executor.rs
+++ b/src/sync/executor.rs
@@ -1,10 +1,10 @@
 use super::task::{Task, TaskType};
 
-use std::sync::Arc;
 use std::future::Future;
+use std::sync::Arc;
 
 pub trait Executor {
   type Output: TaskType;
-  
-  fn execute(&self, future: impl Future<Output=Self::Output> + Send + 'static) -> Arc<Task<Self::Output>>;
+
+  fn execute(&self, future: impl Future<Output = Self::Output> + Send + 'static) -> Arc<Task<Self::Output>>;
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -11,6 +11,6 @@ pub mod buffer;
 pub mod executor;
 pub mod runtime;
 pub mod spinlock;
-pub mod threadpool;
 pub(crate) mod task;
+pub mod threadpool;
 pub mod worker;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -9,6 +9,7 @@
 //! scheduled.
 pub mod buffer;
 pub mod runtime;
-mod spinlock;
+pub mod spinlock;
 pub mod threadpool;
+pub(crate) mod task;
 pub mod worker;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -8,6 +8,7 @@
 //! of execution is important so there should be a choice in how things are
 //! scheduled.
 pub mod buffer;
+pub mod executor;
 pub mod runtime;
 pub mod spinlock;
 pub mod threadpool;

--- a/src/sync/runtime.rs
+++ b/src/sync/runtime.rs
@@ -8,8 +8,7 @@ pub struct Runtime;
 impl Runtime {
   fn get() -> Arc<ThreadPool> {
     lazy_static! {
-      static ref POOL: Arc<ThreadPool> =
-        Arc::new(ThreadPoolBuilder::named("runtime".to_owned()).build());
+      static ref POOL: Arc<ThreadPool> = Arc::new(ThreadPoolBuilder::named("runtime".to_owned()).build());
     }
     POOL.clone()
   }

--- a/src/sync/runtime.rs
+++ b/src/sync/runtime.rs
@@ -2,6 +2,7 @@ use super::threadpool::{Task, ThreadPool, ThreadPoolBuilder};
 
 use std::sync::Arc;
 
+// HashMap<ThreadId, AtomicBool> -> A map of threads to errors. The future will poll this map to see if the worker errored out
 pub struct Runtime;
 
 impl Runtime {

--- a/src/sync/spinlock.rs
+++ b/src/sync/spinlock.rs
@@ -1,28 +1,77 @@
+#![feature(negative_impls)]
 use std::sync::atomic::{fence, AtomicBool, Ordering};
+use std::cell::{Cell, UnsafeCell};
+use std::sync::{LockResult, PoisonError};
+use std::ops::{Deref, DerefMut};
 
-pub struct SpinLock {
+pub struct SpinLock<T> {
   flag: AtomicBool,
+  poisoned: Cell<bool>,
+  inner: UnsafeCell<T>,
 }
 
-impl SpinLock {
-  pub fn new() -> Self {
+pub struct SpinLockGuard<'a, T> {
+  lock: &'a SpinLock<T>,
+}
+
+impl <'a, T> Drop for SpinLockGuard<'a, T> {
+  fn drop(&mut self) {
+    if std::thread::panicking() {
+      *self.lock.poisoned.as_ptr() = true;
+    }
+    unsafe {
+      self.lock.unlock();
+    }
+  }
+}
+
+impl <'a, T> Deref for SpinLockGuard<'a, T> {
+  type Target = T;
+
+  fn deref(&self) -> &Self::Target {
+    unsafe { &*self.lock.inner.get() }
+  }
+}
+
+impl <'a, T> DerefMut for SpinLockGuard<'a, T> {
+  fn deref_mut(&mut self) -> &mut T {
+    unsafe { &mut *self.lock.inner.get() }
+  }
+}
+
+impl <T> !Send for SpinLockGuard<'_, T> {}
+unsafe impl <T: Sync> Sync for SpinLockGuard<'_, T> {}
+
+impl <T> SpinLock<T> {
+  pub fn new(value: T) -> Self {
     SpinLock {
       flag: AtomicBool::new(false),
+      poisoned: Cell::new(false),
+      inner: UnsafeCell::new(value),
     }
   }
 
-  pub unsafe fn lock(&self) {
+  pub fn lock(&self) -> LockResult<SpinLockGuard<'_, T>> {
     while self
       .flag
       .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
       .unwrap()
     {
-      // NOTE: add spin_loop(); here once it becomes stable
+      std::hint::spin_loop();
     }
     fence(Ordering::Acquire);
+    if *self.poisoned.as_ptr() {
+      LockResult::Err(PoisonError::new(SpinLockGuard {
+        lock: self,
+      }))
+    } else {
+      LockResult::Ok(SpinLockGuard {
+        lock: self,
+      })
+    }
   }
 
-  pub unsafe fn unlock(&self) {
+  unsafe fn unlock(&self) {
     self.flag.store(false, Ordering::Release);
   }
 }

--- a/src/sync/spinlock.rs
+++ b/src/sync/spinlock.rs
@@ -1,7 +1,7 @@
-use std::sync::atomic::{fence, AtomicBool, Ordering};
 use std::cell::{Cell, UnsafeCell};
-use std::sync::{LockResult, PoisonError};
 use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{fence, AtomicBool, Ordering};
+use std::sync::{LockResult, PoisonError};
 
 use rand::distributions::{Distribution, Uniform};
 
@@ -18,7 +18,7 @@ pub struct SpinLockGuard<'a, T> {
   lock: &'a SpinLock<T>,
 }
 
-impl <'a, T> Drop for SpinLockGuard<'a, T> {
+impl<'a, T> Drop for SpinLockGuard<'a, T> {
   fn drop(&mut self) {
     if std::thread::panicking() {
       unsafe { *self.lock.poisoned.as_ptr() = true };
@@ -29,7 +29,7 @@ impl <'a, T> Drop for SpinLockGuard<'a, T> {
   }
 }
 
-impl <'a, T> Deref for SpinLockGuard<'a, T> {
+impl<'a, T> Deref for SpinLockGuard<'a, T> {
   type Target = T;
 
   fn deref(&self) -> &Self::Target {
@@ -37,16 +37,16 @@ impl <'a, T> Deref for SpinLockGuard<'a, T> {
   }
 }
 
-impl <'a, T> DerefMut for SpinLockGuard<'a, T> {
+impl<'a, T> DerefMut for SpinLockGuard<'a, T> {
   fn deref_mut(&mut self) -> &mut Self::Target {
     unsafe { &mut *self.lock.inner.get() }
   }
 }
 
-impl <T> !Send for SpinLockGuard<'_, T> {}
-unsafe impl <T: Sync> Sync for SpinLockGuard<'_, T> {}
+impl<T> !Send for SpinLockGuard<'_, T> {}
+unsafe impl<T: Sync> Sync for SpinLockGuard<'_, T> {}
 
-impl <T> SpinLock<T> {
+impl<T> SpinLock<T> {
   pub fn new(value: T) -> Self {
     SpinLock {
       flag: AtomicBool::new(false),
@@ -76,13 +76,9 @@ impl <T> SpinLock<T> {
     }
     fence(Ordering::Acquire);
     if unsafe { *self.poisoned.as_ptr() } {
-      LockResult::Err(PoisonError::new(SpinLockGuard {
-        lock: self,
-      }))
+      LockResult::Err(PoisonError::new(SpinLockGuard { lock: self }))
     } else {
-      LockResult::Ok(SpinLockGuard {
-        lock: self,
-      })
+      LockResult::Ok(SpinLockGuard { lock: self })
     }
   }
 

--- a/src/sync/task.rs
+++ b/src/sync/task.rs
@@ -1,11 +1,11 @@
 use super::spinlock::SpinLock;
 
 use std::error::Error;
-use std::sync::Arc;
-use std::task::{Context, Poll, Waker, Wake};
 use std::fmt::{Debug, Display, Formatter};
-use std::pin::Pin;
 use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll, Wake, Waker};
 
 pub trait TaskType: Send + Clone + 'static {}
 impl<T> TaskType for T where T: Send + Clone + 'static {}
@@ -34,7 +34,7 @@ where
   pub(super) future: Option<Pin<Box<dyn Future<Output = T> + Send>>>,
 }
 
-impl <T> Wake for Task<T>
+impl<T> Wake for Task<T>
 where
   T: TaskType,
 {
@@ -57,7 +57,7 @@ pub enum PollError {
   Error(TaskError),
 }
 
-impl <T> Task<T>
+impl<T> Task<T>
 where
   T: TaskType,
 {

--- a/src/sync/task.rs
+++ b/src/sync/task.rs
@@ -1,0 +1,121 @@
+use super::spinlock::SpinLock;
+
+use std::error::Error;
+use std::sync::Arc;
+use std::task::{Context, Poll, Waker, Wake};
+use std::fmt::{Debug, Display, Formatter};
+use std::pin::Pin;
+use std::future::Future;
+
+pub trait TaskType: Send + Clone + 'static {}
+impl<T> TaskType for T where T: Send + Clone + 'static {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TaskError {
+  Unhealthy,
+}
+
+impl Display for TaskError {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    match self {
+      TaskError::Unhealthy => write!(f, "worker executor panicked"),
+    }
+  }
+}
+
+impl Error for TaskError {}
+
+pub(super) struct TaskInner<T>
+where
+  T: TaskType,
+{
+  pub(super) ready: bool,
+  pub(super) result: Option<Result<T, TaskError>>,
+  pub(super) future: Option<Pin<Box<dyn Future<Output = T> + Send>>>,
+}
+
+impl <T> Wake for Task<T>
+where
+  T: TaskType,
+{
+  fn wake(self: Arc<Self>) {
+    (self.resume)(self.clone());
+  }
+}
+
+pub struct Task<T>
+where
+  T: TaskType,
+{
+  pub(super) inner: SpinLock<TaskInner<T>>,
+  pub(super) resume: Box<dyn Fn(Arc<Task<T>>) + Send + Sync + 'static>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum PollError {
+  NotReady,
+  Error(TaskError),
+}
+
+impl <T> Task<T>
+where
+  T: TaskType,
+{
+  pub fn new<F>(resumer: F, future: Pin<Box<dyn Future<Output = T> + Send>>) -> Self
+  where
+    F: Fn(Arc<Task<T>>) + Send + Sync + 'static,
+  {
+    Task {
+      inner: SpinLock::new(TaskInner {
+        ready: false,
+        result: None,
+        future: Some(future),
+      }),
+      resume: Box::new(resumer),
+    }
+  }
+
+  pub fn poll(&self) -> Result<T, PollError> {
+    let guard = self.inner.lock().unwrap();
+    if guard.ready {
+      guard.result.clone().unwrap().map_err(PollError::Error)
+    } else {
+      Err(PollError::NotReady)
+    }
+  }
+
+  pub fn wait(&self) -> Result<T, TaskError> {
+    // TODO: Implement non busy wait version
+    loop {
+      std::thread::yield_now();
+      let poll = self.poll();
+      if let Err(error) = poll {
+        match error {
+          PollError::NotReady => (),
+          PollError::Error(error) => return Err(error),
+        }
+      } else {
+        return Ok(poll.unwrap());
+      }
+    }
+  }
+
+  pub(super) fn progress(self: Arc<Self>) -> bool {
+    if let Some(mut future) = self.inner.lock().unwrap().future.take() {
+      let waker = Waker::from(self.clone());
+      let context = &mut Context::from_waker(&waker);
+      let poll = future.as_mut().poll(context);
+      let mut guard = self.inner.lock().unwrap();
+      if let Poll::Ready(value) = poll {
+        guard.ready = true;
+        guard.result = Some(Ok(value));
+        true
+      } else {
+        guard.future = Some(future);
+        false
+      }
+    } else {
+      false
+    }
+  }
+}

--- a/src/sync/threadpool.rs
+++ b/src/sync/threadpool.rs
@@ -139,8 +139,9 @@ impl ThreadPool {
         }
       };
       *guard = ThreadPoolStatus::Pending(count + 1);
+      self.shared.signal.1.notify_one();
+
     }
-    self.shared.signal.1.notify_one();
   }
 
   /// Returns true if pool has completed all jobs and is standing idle

--- a/src/sync/threadpool.rs
+++ b/src/sync/threadpool.rs
@@ -17,9 +17,7 @@ impl Task {
   where
     F: Fn() + Send + Sync + 'static,
   {
-    Task {
-      func: Box::new(func),
-    }
+    Task { func: Box::new(func) }
   }
 
   pub fn invoke(self) {
@@ -140,15 +138,13 @@ impl ThreadPool {
       };
       *guard = ThreadPoolStatus::Pending(count + 1);
       self.shared.signal.1.notify_one();
-
     }
   }
 
   /// Returns true if pool has completed all jobs and is standing idle
   pub fn done(&self) -> bool {
     let _guard = self.shared.signal.0.lock().unwrap();
-    self.shared.running_count.load(Ordering::Relaxed) == 0
-      && self.shared.jobs.lock().unwrap().is_empty()
+    self.shared.running_count.load(Ordering::Relaxed) == 0 && self.shared.jobs.lock().unwrap().is_empty()
   }
 
   fn worker(name: String, shared: Arc<SharedData>) -> JoinHandle<()> {

--- a/src/sync/worker.rs
+++ b/src/sync/worker.rs
@@ -1,51 +1,123 @@
-use super::threadpool::Task;
+use super::task::{TaskType, Task, TaskError};
+use super::executor::Executor;
 
-use std::sync::atomic::{AtomicIsize, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
+use std::future::Future;
 
-enum WorkerSignal {
-  Run(Task),
-  Close,
+pub type WorkerResult<T> = Result<T, TaskError>; 
+
+// panic if submit on non healthy worker
+
+pub struct HealthUnwinder<'a, T>
+where
+  T: TaskType,
+{
+  flag: Arc<AtomicBool>,
+  holding: Option<Arc<Task<T>>>,
+  receiver: &'a Receiver<WorkerSignal<T>>,
 }
 
-pub struct Worker {
-  sender: Mutex<Sender<WorkerSignal>>,
-  queued: Arc<AtomicIsize>,
-  handle: Option<JoinHandle<()>>,
-}
-
-impl Default for Worker {
-  fn default() -> Self {
-    let (tx, rx) = std::sync::mpsc::channel();
-    let queued = Arc::new(AtomicIsize::new(0));
-    Worker {
-      sender: Mutex::new(tx),
-      queued: queued.clone(),
-      handle: Some(Self::run(rx, queued)),
+impl <'a, T> Drop for HealthUnwinder<'a, T>
+where
+  T: TaskType,
+{
+  fn drop(&mut self) {
+    if std::thread::panicking() {
+      self.flag.store(false, Ordering::Relaxed);
+      for signal in self.receiver.try_iter() {
+        if let WorkerSignal::Run(task) = &signal {
+          if let Ok(guard) = &mut task.inner.lock() {
+            guard.ready = true;
+            guard.result = Some(Err(TaskError::Unhealthy));
+          }
+        }
+      }
     }
   }
 }
 
-impl Worker {
+enum WorkerSignal<T>
+where
+  T: TaskType,
+{
+  Run(Arc<Task<T>>),
+  Close,
+}
+
+pub struct WorkerInner<T>
+where
+  T: TaskType,
+{
+  sender: Mutex<Sender<WorkerSignal<T>>>,
+  queued: Arc<AtomicIsize>,
+  healthy: Arc<AtomicBool>,
+}
+
+#[derive(Clone)]
+pub struct Worker<T = ()>
+where
+  T: TaskType,
+{
+  inner: Arc<WorkerInner<T>>,
+}
+
+impl <T> Default for Worker<T>
+where
+  T: TaskType,
+{
+  fn default() -> Self {
+    Self::new_with_handle().0
+  }
+}
+
+impl <T> Worker<T>
+where
+  T: TaskType,
+{
+  fn new_with_handle() -> (Self, JoinHandle<()>) {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let queued = Arc::new(AtomicIsize::new(0));
+    let healthy = Arc::new(AtomicBool::new(true));
+    (
+      Worker {
+        inner: Arc::new(WorkerInner {
+          sender: Mutex::new(tx),
+          queued: queued.clone(),
+          healthy: healthy.clone(),
+        }),
+      },
+      Self::run(rx, queued, healthy),
+    )
+  }
+
   pub fn new() -> Self {
     Self::default()
   }
 
   fn run(
-    receiver: Receiver<WorkerSignal>,
+    receiver: Receiver<WorkerSignal<T>>,
     queued: Arc<AtomicIsize>,
+    healthy: Arc<AtomicBool>
   ) -> JoinHandle<()> {
     static mut ID: AtomicUsize = AtomicUsize::new(0);
     let id = unsafe { ID.fetch_add(1, Ordering::Relaxed) };
     std::thread::Builder::new()
       .name(format!("worker{}", id))
       .spawn(move || {
-        crate::utils::sync::kill_process_on_panic();
+        let mut unwinder = HealthUnwinder {
+          flag: healthy,
+          holding: None,
+          receiver: &receiver,
+        };
         while let WorkerSignal::Run(task) = receiver.recv().unwrap() {
-          task.invoke();
-          queued.fetch_add(-1, Ordering::Relaxed);
+          unwinder.holding = Some(task.clone());
+          if Task::progress(task) {
+            queued.fetch_add(-1, Ordering::Relaxed);
+          }
+          unwinder.holding.take();
         }
       })
       .unwrap()
@@ -55,9 +127,13 @@ impl Worker {
   ///
   /// `submit` sends the task to the worker thread using a channel
   ///
-  /// - Tasks are guaranteed to be run, when the `Worker` instance is
+  /// - Tasks are guaranteed to be run as long as the worker remains healthy, when the `Worker` instance is
   /// dropped the dropping thread signals the worker to close. Once the worker
   /// receives this signal it quits its thread loop.
+  /// 
+  /// # Panics
+  /// 
+  /// Panics if the worker is unhealthy.
   ///
   /// # Example
   /// ```
@@ -73,66 +149,120 @@ impl Worker {
   /// }
   /// assert_eq!(atomic.load(Ordering::Relaxed), 15);
   /// ```
-  pub fn submit<F>(&self, job: F)
+  pub fn submit<F>(&self, job: impl FnOnce() -> F) -> Arc<Task<T>>
   where
-    F: Fn() + Send + Sync + 'static,
+    F: Future<Output = T> + Send + 'static,
   {
-    self.submit_raw(Task::new(job));
+    self.execute(job())
   }
 
-  pub fn submit_raw(&self, task: Task) {
-    self.queued.fetch_add(1, Ordering::Relaxed);
-    self
-      .sender
-      .lock()
-      .unwrap()
-      .send(WorkerSignal::Run(task))
-      .unwrap();
+  pub fn idle(&self) -> bool {
+    self.inner.queued.load(Ordering::Relaxed) == 0
   }
 
-  pub fn done(&self) -> bool {
-    self.queued.load(Ordering::Relaxed) == 0
+  pub fn healthy(&self) -> bool {
+    self.inner.healthy.load(Ordering::Relaxed)
   }
 }
 
-impl Drop for Worker {
-  fn drop(&mut self) {
-    self
-      .sender
-      .lock()
-      .unwrap()
-      .send(WorkerSignal::Close)
-      .unwrap();
-    if let Some(handle) = self.handle.take() {
-      if std::thread::current().id() != handle.thread().id() {
-        handle
-          .join()
-          .expect("expected worker thread to join gracefully");
+impl <T> WorkerInner<T>
+where
+  T: TaskType,
+{
+  pub fn enqueue(&self, task: Arc<Task<T>>, resuming: bool) {
+    let guard = self.sender.lock().unwrap();
+    if self.healthy.load(Ordering::Relaxed) {
+      if !resuming {
+        self.queued.fetch_add(1, Ordering::Relaxed);
       }
+      guard.send(WorkerSignal::Run(task)).unwrap();
+    } else {
+      let mut guard = task.inner.lock().unwrap();
+      guard.result = Some(Err(TaskError::Unhealthy));
+      guard.ready = true;
     }
   }
 }
+
+impl <T> Executor for Worker<T>
+where
+  T: TaskType,
+{
+  type Output = T;
+  fn execute(&self, future: impl Future<Output = Self::Output> + Send + 'static) -> Arc<Task<Self::Output>> {
+    let cloned = self.inner.clone();
+    let task = Arc::new(Task::new(move |task| { cloned.enqueue(task, true) }, Box::pin(future)));
+    self.inner.enqueue(task.clone(), false);
+    task
+  }
+}
+
+impl <T> Drop for Worker<T>
+where T: TaskType {
+  fn drop(&mut self) {
+    let _ = self
+      .inner
+      .sender
+      .lock()
+      .unwrap()
+      .send(WorkerSignal::Close);
+  }
+}
+
+// pub struct WorkerHandle {
+//   worker: Arc<Worker>,
+//   pool: Weak<Pool>,
+// }
+
+// pub struct Pool {
+//   workers: RwLock<Vec<Arc<Worker>>>,
+//   available: RwLock<Vec<usize>>,
+// }
+
+// impl Pool {
+//   pub fn new() -> Self {
+//     Pool {
+//       workers: RwLock::new(Vec::new()),
+//       available: RwLock::new(Vec::new()),
+//     }
+//   }
+// }
 
 #[cfg(test)]
 mod test {
   use super::*;
   use crate::utils::testing::async_context;
 
-  use std::sync::atomic::AtomicUsize;
+  #[test]
+  fn worker_new_test() {
+    async_context(|| {
+      let worker: Worker = Worker::new();
+      assert!(worker.inner.healthy.load(Ordering::Relaxed));
+      assert!(worker.healthy());
+      assert_eq!(worker.inner.queued.load(Ordering::Relaxed), 0);
+      assert!(worker.idle());
+      assert!(!worker.inner.sender.is_poisoned());
+    });
+  }
 
   #[test]
-  fn submit_worker_jobs_test() {
+  fn worker_healthy_task_test() {
     async_context(|| {
-      let worker = Worker::new();
-      let atomic = Arc::new(AtomicUsize::new(0));
-      for _ in 0..100 {
-        let reference = atomic.clone();
-        worker.submit(move || {
-          reference.fetch_add(1, Ordering::Relaxed);
-        });
-      }
-      while !worker.done() {}
-      assert_eq!(atomic.load(Ordering::Relaxed), 100);
+      let (worker, handle) = Worker::<()>::new_with_handle();
+      let task = worker.submit(async || {});
+      worker.inner.sender.lock().unwrap().send(WorkerSignal::Close).unwrap();
+      assert!(handle.join().is_ok());
+      assert_eq!(task.poll(), Ok(()));
     });
+  }
+
+  #[test]
+  #[should_panic]
+  fn worker_unhealthy_task_test() {
+    let (worker, handle) = Worker::<()>::new_with_handle();
+    let task = worker.submit(async || { panic!() });
+    worker.inner.sender.lock().unwrap().send(WorkerSignal::Close).unwrap();
+    assert!(handle.join().is_err());
+    assert_eq!(task.poll(), Ok(()));
   }
 }

--- a/src/utils/sync.rs
+++ b/src/utils/sync.rs
@@ -10,16 +10,9 @@ pub fn kill_process_on_panic() {
       "unknown"
     };
     if !log::log_enabled!(log::Level::Error) {
-      println!(
-        "unhandled panic on thread '{}' with info: '{}'",
-        name, panic_info
-      );
+      println!("unhandled panic on thread '{}' with info: '{}'", name, panic_info);
     }
-    log::error!(
-      "unhandled panic on thread '{}' with info: '{}'",
-      name,
-      panic_info
-    );
+    log::error!("unhandled panic on thread '{}' with info: '{}'", name, panic_info);
     std::process::exit(-1);
   }));
 }

--- a/src/utils/testing.rs
+++ b/src/utils/testing.rs
@@ -18,7 +18,10 @@ where
     .unwrap();
   match done_rx.recv_timeout(d) {
     Ok(_) => handle.join().expect("thread panicked"),
-    _ => panic!("thread took too long"),
+    Err(error) => match error {
+      mpsc::RecvTimeoutError::Timeout => panic!("thread took too long"),
+      mpsc::RecvTimeoutError::Disconnected => panic!("thread panicked"),
+    },
   }
 }
 

--- a/tests/event_test.rs
+++ b/tests/event_test.rs
@@ -50,10 +50,7 @@ fn take_observable_of_test() {
           subscribe_sum.fetch_add(x, Ordering::Relaxed);
         })
         .finalize(move || {
-          tx.lock()
-            .unwrap()
-            .send(finalize_sum.load(Ordering::Relaxed))
-            .unwrap();
+          tx.lock().unwrap().send(finalize_sum.load(Ordering::Relaxed)).unwrap();
         });
       assert_eq!(rx.recv().unwrap(), 6);
     }
@@ -68,9 +65,7 @@ fn first_subject_test() {
     let finalize_sum = sum.clone();
     let (tx, rx) = std::sync::mpsc::channel();
     let tx = Mutex::new(tx.clone());
-    let subject = BasicSubjectBuilder::new()
-      .scheduler(SchedulerType::Blocking)
-      .build();
+    let subject = BasicSubjectBuilder::new().scheduler(SchedulerType::Blocking).build();
     {
       let _subscription = subject
         .observe()
@@ -80,10 +75,7 @@ fn first_subject_test() {
           subscribe_sum.fetch_add(x, Ordering::Relaxed);
         })
         .finalize(move || {
-          tx.lock()
-            .unwrap()
-            .send(finalize_sum.load(Ordering::Relaxed))
-            .unwrap();
+          tx.lock().unwrap().send(finalize_sum.load(Ordering::Relaxed)).unwrap();
         });
       subject.next(5)
     }
@@ -95,12 +87,7 @@ fn first_subject_test() {
 fn map_event_to_string_test() {
   testing::async_context(|| {
     let subject = BasicSubject::new();
-    let rx = subject
-      .observe()
-      .pipe()
-      .take(3)
-      .map(|x| format!("{}_", x))
-      .collect();
+    let rx = subject.observe().pipe().take(3).map(|x| format!("{}_", x)).collect();
     subject.next("abc");
     subject.next("def");
     subject.next("ghi");
@@ -134,12 +121,8 @@ fn complex_pipe_test() {
 #[test]
 fn multi_observable_test() {
   testing::async_context(|| {
-    let subject = BasicSubjectBuilder::new()
-      .scheduler(SchedulerType::Worker)
-      .build();
-    let done = BasicSubjectBuilder::new()
-      .scheduler(SchedulerType::Blocking)
-      .build();
+    let subject = BasicSubjectBuilder::new().scheduler(SchedulerType::Worker).build();
+    let done = BasicSubjectBuilder::new().scheduler(SchedulerType::Blocking).build();
     let list = Arc::new(Mutex::new(Vec::new()));
     let cloned = list.clone();
     let (tx, rx) = std::sync::mpsc::channel();


### PR DESCRIPTION
closes #7 

Implements a futures based worker which allows you to poll and wait for the completion of a scheduled task by using `Task::poll` and `Task::wait`. Also implements a proper RAII spinlock implementation (with a randomized backoff to address lock contention).

# Unstable Features

This PR adds the following unstable features to this lib:

- `negative_impls` for the spinlock implementation
- `async_closure` for the usage of async closures as the jobs
